### PR TITLE
Improve testing coverage

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -54,7 +54,22 @@ set(CMAKE_HIP_ARCHITECTURES OFF)
 
 file(GLOB SOURCES "*.cpp")
 
+list(REMOVE_ITEM SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/vector_add_assert_trap_no_debug_info.cpp")
 set_source_files_properties(${SOURCES} PROPERTIES HIP_SOURCE_PROPERTY_FORMAT 1)
+
+set(NODEBUG_SRC   "${CMAKE_CURRENT_SOURCE_DIR}/vector_add_assert_trap_no_debug_info.cpp")
+set(NODEBUG_OBJ   "${CMAKE_CURRENT_BINARY_DIR}/vector_add_assert_trap_no_debug_info.o")
+
+add_custom_command(
+  OUTPUT ${NODEBUG_OBJ}
+  COMMAND ${HIP_HIPCC_EXECUTABLE}
+          -g0
+          -O0
+          -c ${NODEBUG_SRC}
+          -o ${NODEBUG_OBJ}
+  DEPENDS ${NODEBUG_SRC}
+  COMMENT "Compiling vector_add_assert_trap_no_debug_info.cpp without debug info"
+)
 
 add_custom_command(
   OUTPUT "snapshot_objfile_on_load.hipfb"
@@ -70,7 +85,7 @@ add_custom_command(
   COMMENT "Building save_code_objects.hipfb"
   VERBATIM)
 
-hip_add_executable(rocm-debug-agent-test ${SOURCES} CLANG_OPTIONS -ggdb)
+hip_add_executable(rocm-debug-agent-test ${SOURCES} ${NODEBUG_OBJ} CLANG_OPTIONS -ggdb)
 
 add_custom_target(snapshot_objfile_on_load-tgt DEPENDS snapshot_objfile_on_load.hipfb)
 add_custom_target(save_code_objects-tgt DEPENDS save_code_objects.hipfb)

--- a/test/debug_agent_test.cpp
+++ b/test/debug_agent_test.cpp
@@ -38,6 +38,7 @@ extern void VectorAddMemoryFaultTest ();
 extern void SnapshotCodeObjOnLoadTest ();
 extern void SaveCodeObjectTest ();
 extern void PrintAllWavesTest ();
+extern void SigquitTest ();
 
 static void PrintTestInfo (const char *header);
 static void RunVectorAddDebugTrapTest ();
@@ -46,6 +47,7 @@ static void RunVectorAddMemoryFaultTest ();
 static void RunSnapshotCodeObjOnLoadTest ();
 static void RunSaveCodeObjectTest ();
 static void RunPrintAllWavesTest ();
+static void RunSigquitTest ();
 
 int
 main (int argc, char *argv[])
@@ -92,6 +94,9 @@ main (int argc, char *argv[])
           break;
         case 5:
           RunPrintAllWavesTest ();
+          break;
+        case 6:
+          RunSigquitTest ();
           break;
         default:
           std::cout << "  *** Invalid Test ID ***" << std::endl;
@@ -226,4 +231,24 @@ RunPrintAllWavesTest ()
       TEST_ASSERT (err == hipSuccess, "hipDeviceReset");
     }
   PrintTestInfo ("PrintAllWaves end");
+}
+
+static void
+RunSigquitTest ()
+{
+  PrintTestInfo ("Sigquit start");
+  int deviceCount;
+  hipError_t err = hipGetDeviceCount (&deviceCount);
+  TEST_ASSERT (err == hipSuccess, "hipGetDeviceCount");
+  for (int i = 0; i < deviceCount; ++i)
+    {
+      err = hipSetDevice (i);
+      TEST_ASSERT (err == hipSuccess, "hipSetDevice");
+
+      SigquitTest ();
+
+      err = hipDeviceReset ();
+      TEST_ASSERT (err == hipSuccess, "hipDeviceReset");
+    }
+  PrintTestInfo ("Sigquit end");
 }

--- a/test/debug_agent_test.cpp
+++ b/test/debug_agent_test.cpp
@@ -37,6 +37,7 @@ extern void VectorAddDebugTrapTest ();
 extern void VectorAddMemoryFaultTest ();
 extern void SnapshotCodeObjOnLoadTest ();
 extern void SaveCodeObjectTest ();
+extern void PrintAllWavesTest ();
 
 static void PrintTestInfo (const char *header);
 static void RunVectorAddDebugTrapTest ();
@@ -44,6 +45,7 @@ static void RunVectorAddNormalTest ();
 static void RunVectorAddMemoryFaultTest ();
 static void RunSnapshotCodeObjOnLoadTest ();
 static void RunSaveCodeObjectTest ();
+static void RunPrintAllWavesTest ();
 
 int
 main (int argc, char *argv[])
@@ -87,6 +89,9 @@ main (int argc, char *argv[])
           break;
         case 4:
           RunSaveCodeObjectTest ();
+          break;
+        case 5:
+          RunPrintAllWavesTest ();
           break;
         default:
           std::cout << "  *** Invalid Test ID ***" << std::endl;
@@ -201,4 +206,24 @@ RunSaveCodeObjectTest ()
 {
   PrintTestInfo ("SaveCodeObjectTest start");
   SaveCodeObjectTest ();
+}
+
+static void
+RunPrintAllWavesTest ()
+{
+  PrintTestInfo ("PrintAllWaves start");
+  int deviceCount;
+  hipError_t err = hipGetDeviceCount (&deviceCount);
+  TEST_ASSERT (err == hipSuccess, "hipGetDeviceCount");
+  for (int i = 0; i < deviceCount; ++i)
+    {
+      err = hipSetDevice (i);
+      TEST_ASSERT (err == hipSuccess, "hipSetDevice");
+
+      PrintAllWavesTest ();
+
+      err = hipDeviceReset ();
+      TEST_ASSERT (err == hipSuccess, "hipDeviceReset");
+    }
+  PrintTestInfo ("PrintAllWaves end");
 }

--- a/test/debug_agent_test.cpp
+++ b/test/debug_agent_test.cpp
@@ -39,6 +39,7 @@ extern void SnapshotCodeObjOnLoadTest ();
 extern void SaveCodeObjectTest ();
 extern void PrintAllWavesTest ();
 extern void SigquitTest ();
+extern void VectorAddDebugTrapTestNoDebug ();
 
 static void PrintTestInfo (const char *header);
 static void RunVectorAddDebugTrapTest ();
@@ -48,6 +49,7 @@ static void RunSnapshotCodeObjOnLoadTest ();
 static void RunSaveCodeObjectTest ();
 static void RunPrintAllWavesTest ();
 static void RunSigquitTest ();
+static void RunVectorAddDebugTrapTestNoDebug ();
 
 int
 main (int argc, char *argv[])
@@ -97,6 +99,9 @@ main (int argc, char *argv[])
           break;
         case 6:
           RunSigquitTest ();
+          break;
+        case 7:
+          RunVectorAddDebugTrapTestNoDebug ();
           break;
         default:
           std::cout << "  *** Invalid Test ID ***" << std::endl;
@@ -251,4 +256,25 @@ RunSigquitTest ()
       TEST_ASSERT (err == hipSuccess, "hipDeviceReset");
     }
   PrintTestInfo ("Sigquit end");
+}
+
+static void
+RunVectorAddDebugTrapTestNoDebug ()
+{
+  PrintTestInfo ("No debug info start");
+  int deviceCount;
+  hipError_t err = hipGetDeviceCount (&deviceCount);
+  TEST_ASSERT (err == hipSuccess, "hipGetDeviceCount");
+
+  for (int i = 0; i < deviceCount; ++i)
+    {
+      err = hipSetDevice (i);
+      TEST_ASSERT (err == hipSuccess, "hipSetDevice");
+
+      VectorAddDebugTrapTestNoDebug ();
+
+      err = hipDeviceReset ();
+      TEST_ASSERT (err == hipSuccess, "hipDeviceReset");
+    }
+  PrintTestInfo ("No debug info end");
 }

--- a/test/print_all_waves.cpp
+++ b/test/print_all_waves.cpp
@@ -1,0 +1,22 @@
+#pragma clang optimize off
+#include "util.h"
+#include <hip/hip_runtime.h>
+
+__global__ void
+print_all_waves_kern ()
+{
+  if (threadIdx.x == 0)
+    abort ();
+  /* Make sure that by the time the debug agent prints all the waves following
+     the abort, other waves in the workgroup are still present.  */
+  __syncthreads ();
+}
+
+void
+PrintAllWavesTest ()
+{
+  hipError_t err;
+  print_all_waves_kern<<<2, 512>>> ();
+  err = hipDeviceSynchronize ();
+  TEST_ASSERT (err == hipSuccess, "kernel error");
+}

--- a/test/run-test.py
+++ b/test/run-test.py
@@ -341,6 +341,45 @@ def check_test_8():
             print("No .debug_info section found in any code object.")
             return False
 
+# test 9
+def check_test_9():
+    print("Starting rocm-debug-agent test 9")
+
+    check_list = [
+        'wave_1',
+        'wave_2',
+        'wave_3',
+        'wave_4',
+        'wave_5',
+        'wave_6',
+        'wave_7',
+        'wave_8',
+    ]
+
+    with unittest.mock.patch.dict(os.environ, {"ROCM_DEBUG_AGENT_OPTIONS":
+                                                   f"--all"}):
+        p = Popen(['./rocm-debug-agent-test', '5'], stdout=PIPE, stderr=PIPE)
+        output, err = p.communicate()
+        out_str = output.decode('utf-8')
+        err_str = err.decode('utf-8')
+
+        # check output string
+        all_output_string_found = True
+        for check_str in check_list:
+            pattern = re.compile(check_str)
+            if (not (pattern.search(err_str))):
+                all_output_string_found = False
+                print ("\"", check_str, "\" Not Found in dump.")
+
+        if (not all_output_string_found):
+            print("rocm-debug-agent test print out.")
+            print(out_str)
+            print("rocm-debug-agent test error message.")
+            print(err_str)
+
+        return all_output_string_found
+
+
 test_success = True
 
 for deferred_loading in (None, "1", "0"):
@@ -362,6 +401,7 @@ for deferred_loading in (None, "1", "0"):
         test_success &= check_test_6()
         test_success &= check_test_7()
         test_success &= check_test_8()
+        test_success &= check_test_9()
 
 if (test_success):
     print("rocm-debug-agent test Pass!")

--- a/test/run-test.py
+++ b/test/run-test.py
@@ -276,6 +276,37 @@ def check_test_6():
 
         return all_output_string_found
 
+# test 7
+def check_test_7():
+    print("Starting rocm-debug-agent test 7")
+
+    check_list = ['rocm-dbgapi',
+                  ]
+
+    with unittest.mock.patch.dict(os.environ, {"ROCM_DEBUG_AGENT_OPTIONS":
+                                                   f"-l info"}):
+        p = Popen(['./rocm-debug-agent-test', '1'], stdout=PIPE, stderr=PIPE)
+        output, err = p.communicate()
+        out_str = output.decode('utf-8')
+        err_str = err.decode('utf-8')
+
+        # check output string
+        all_output_string_found = True
+        for check_str in check_list:
+            pattern = re.compile(check_str)
+            if (not (pattern.search(err_str))):
+                all_output_string_found = False
+                print ("\"", check_str, "\" Not Found in dump.")
+
+        if (not all_output_string_found):
+            print("rocm-debug-agent test print out.")
+            print(out_str)
+            print("rocm-debug-agent test error message.")
+            print(err_str)
+
+
+        return all_output_string_found
+
 test_success = True
 
 for deferred_loading in (None, "1", "0"):
@@ -295,6 +326,7 @@ for deferred_loading in (None, "1", "0"):
         test_success &= check_test_4()
         test_success &= check_test_5()
         test_success &= check_test_6()
+        test_success &= check_test_7()
 
 if (test_success):
     print("rocm-debug-agent test Pass!")

--- a/test/run-test.py
+++ b/test/run-test.py
@@ -418,6 +418,40 @@ def check_test_10():
 
     return all_output_string_found
 
+# test 11 check for difference in outputs for same program compiled with and
+# without -ggdb flag
+def check_test_11():
+    print("Starting rocm-debug-agent test 11")
+
+    check_list = [
+                  'c[gid] = a[gid] + b[gid] + (lds_check[0] >> 32);',
+                  'if (gid == 0)',
+                  ]
+    check_list = [re.escape(s) for s in check_list]
+
+    p_debug = Popen(['./rocm-debug-agent-test', '1'], stdout=PIPE, stderr=PIPE)
+    output, err = p_debug.communicate()
+    err_str_debug = err.decode('utf-8')
+
+    p_no_debug = Popen(['./rocm-debug-agent-test', '7'], stdout=PIPE, stderr=PIPE)
+    output, err = p_no_debug.communicate()
+    err_str_no_debug = err.decode('utf-8')
+
+    # check if string is in dissasembly of code with debug info but not in other one
+    found_in_debug = False
+    found_in_no_debug = False
+    for check_str in check_list:
+        pattern = re.compile(check_str)
+        if ((pattern.search(err_str_debug))):
+            found_in_debug = True
+
+    for check_str in check_list:
+        pattern = re.compile(check_str)
+        if ((pattern.search(err_str_no_debug))):
+            found_in_no_debug = True
+
+    return found_in_debug and not found_in_no_debug
+
 test_success = True
 
 for deferred_loading in (None, "1", "0"):
@@ -441,6 +475,7 @@ for deferred_loading in (None, "1", "0"):
         test_success &= check_test_8()
         test_success &= check_test_9()
         test_success &= check_test_10()
+        test_success &= check_test_11()
 
 if (test_success):
     print("rocm-debug-agent test Pass!")

--- a/test/run-test.py
+++ b/test/run-test.py
@@ -210,6 +210,42 @@ def check_test_4():
 
             return True
 
+# test 5
+def check_test_5():
+    print("Starting rocm-debug-agent test 5")
+
+
+    check_list = [
+                  's0:',
+                  'v0:',
+                  '0x0000: 22222222 11111111', # First uint64_t in LDS is '1111111122222222'
+                  'Disassembly for function vector_add_assert_trap\\(int\\*, int\\*, int\\*\\)'
+                  ]
+
+
+    with unittest.mock.patch.dict(os.environ, {"ROCM_DEBUG_AGENT_OPTIONS":
+                                                   f"-o output_log.txt"}):
+        # Start process without capturing output
+        p = Popen(['./rocm-debug-agent-test', '1'])
+        p.wait()  # Wait for the process to complete
+
+        # Read the output log
+        with open("output_log.txt", "r") as f:
+            log_contents = f.read()
+
+        all_output_string_found = True
+        for check_str in check_list:
+            pattern = re.compile(check_str)
+            if not pattern.search(log_contents):
+                all_output_string_found = False
+                print(f'"{check_str}" Not Found in output_log.txt.')
+
+        if not all_output_string_found:
+            print("Full output log contents:")
+            print(log_contents)
+
+        return all_output_string_found
+
 test_success = True
 
 for deferred_loading in (None, "1", "0"):
@@ -227,6 +263,7 @@ for deferred_loading in (None, "1", "0"):
         test_success &= check_test_2()
         test_success &= check_test_3()
         test_success &= check_test_4()
+        test_success &= check_test_5()
 
 if (test_success):
     print("rocm-debug-agent test Pass!")

--- a/test/run-test.py
+++ b/test/run-test.py
@@ -63,7 +63,6 @@ def check_test_0():
 def check_test_1():
     print("Starting rocm-debug-agent test 1")
 
-    #TODO: use regular expressions instead of strings
     check_list = ['HSA_STATUS_ERROR_EXCEPTION: An HSAIL operation resulted in a hardware exception\\.',
                   '\\(stopped, reason: ASSERT_TRAP\\)',
                    'exec: (00000000)?00000001',
@@ -105,7 +104,6 @@ def check_test_1():
 def check_test_2():
     print("Starting rocm-debug-agent test 2")
 
-    #TODO: use regular expressions instead of strings
     check_list = [
 #                  'System event \(HSA_AMD_GPU_MEMORY_FAULT_EVENT\)',
 #                  'Faulting page: 0x',
@@ -175,7 +173,7 @@ def check_test_3():
 
     return not found_error
 
-# test 3: save code object on disk
+# test 4: save code object on disk
 def check_test_4():
     print("Starting rocm-debug-agent test 4")
 
@@ -464,18 +462,28 @@ for deferred_loading in (None, "1", "0"):
             print(f"### Testing with HIP_ENABLE_DEFERRED_LOADING={deferred_loading}")
             os.environ["HIP_ENABLE_DEFERRED_LOADING"] = deferred_loading
 
-        test_success &= check_test_0()
-        test_success &= check_test_1()
-        test_success &= check_test_2()
-        test_success &= check_test_3()
-        test_success &= check_test_4()
-        test_success &= check_test_5()
-        test_success &= check_test_6()
-        test_success &= check_test_7()
-        test_success &= check_test_8()
-        test_success &= check_test_9()
-        test_success &= check_test_10()
-        test_success &= check_test_11()
+        test_list = [
+            check_test_0,
+            check_test_1,
+            check_test_2,
+            check_test_3,
+            check_test_4,
+            check_test_5,
+            check_test_6,
+            check_test_7,
+            check_test_8,
+            check_test_9,
+            check_test_10,
+            check_test_11,
+            ]
+
+        for i, test in enumerate(test_list, start=0):
+            result = test()
+            test_success &= result
+            if result:
+                print(f"Test {i} PASS")
+            else:
+                print(f"Test {i} FAIL")
 
 if (test_success):
     print("rocm-debug-agent test Pass!")

--- a/test/run-test.py
+++ b/test/run-test.py
@@ -5,6 +5,7 @@ import inspect
 import tempfile
 import unittest.mock
 from subprocess import Popen, PIPE
+from glob import glob
 
 
 def filter_warnings(err_str):
@@ -307,6 +308,39 @@ def check_test_7():
 
         return all_output_string_found
 
+# test 8
+def check_test_8():
+    print("Starting rocm-debug-agent test 8")
+
+    # Set up environment to save code objects in the current directory
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with unittest.mock.patch.dict(os.environ, {"ROCM_DEBUG_AGENT_OPTIONS":
+                                                    f"-s {tmpdir}"}):
+
+            # Run the test binary
+            p = Popen(['./rocm-debug-agent-test', '1'], stdout=PIPE, stderr=PIPE)
+            output, err = p.communicate()
+
+            code_objects = os.listdir(tmpdir)
+            if (len(code_objects) == 0):
+                print(f"No code object found in {tmpdir}")
+                return False
+
+            code_obj_files = [os.path.join(tmpdir,co) for co in code_objects if "file___" in co]
+            if not code_obj_files:
+                print("No code object file was generated.")
+                return False
+
+            # Inspect each code object with objdump
+            for f in code_obj_files:
+                objdump = Popen(["objdump", "-h", f], stdout=PIPE, stderr=PIPE)
+                out, _ = objdump.communicate()
+                if b".debug_info" in out:
+                    return True
+
+            print("No .debug_info section found in any code object.")
+            return False
+
 test_success = True
 
 for deferred_loading in (None, "1", "0"):
@@ -327,6 +361,7 @@ for deferred_loading in (None, "1", "0"):
         test_success &= check_test_5()
         test_success &= check_test_6()
         test_success &= check_test_7()
+        test_success &= check_test_8()
 
 if (test_success):
     print("rocm-debug-agent test Pass!")

--- a/test/run-test.py
+++ b/test/run-test.py
@@ -6,6 +6,8 @@ import tempfile
 import unittest.mock
 from subprocess import Popen, PIPE
 from glob import glob
+import time
+import signal
 
 
 def filter_warnings(err_str):
@@ -379,6 +381,42 @@ def check_test_9():
 
         return all_output_string_found
 
+# test 10 SIGQUIT
+def check_test_10():
+    print("Starting rocm-debug-agent test 10")
+
+    check_list = [
+                  's0:',
+                  'v0:',
+                  'Disassembly for function sigquit_kern\\(\\)'
+                  ]
+
+    p = Popen(['./rocm-debug-agent-test', '6'], stdout=PIPE, stderr=PIPE)
+    time.sleep(5)
+    os.kill(p.pid, signal.SIGQUIT)
+    time.sleep(5)
+    p.terminate()
+    output, err = p.communicate()
+    out_str = output.decode('utf-8')
+    err_str = err.decode('utf-8')
+
+
+    # check output string
+    all_output_string_found = True
+    for check_str in check_list:
+        pattern = re.compile(check_str)
+        if (not (pattern.search(err_str))):
+            all_output_string_found = False
+            print ("\"", check_str, "\" Not Found in dump.")
+
+    if (not all_output_string_found):
+        print("rocm-debug-agent test print out.")
+        print(out_str)
+        print("rocm-debug-agent test error message.")
+        print(err_str)
+
+
+    return all_output_string_found
 
 test_success = True
 
@@ -402,6 +440,7 @@ for deferred_loading in (None, "1", "0"):
         test_success &= check_test_7()
         test_success &= check_test_8()
         test_success &= check_test_9()
+        test_success &= check_test_10()
 
 if (test_success):
     print("rocm-debug-agent test Pass!")

--- a/test/run-test.py
+++ b/test/run-test.py
@@ -246,6 +246,36 @@ def check_test_5():
 
         return all_output_string_found
 
+# test 6
+def check_test_6():
+    print("Starting rocm-debug-agent test 6")
+
+    check_list = ['ROCdebug-agent usage',
+                  ]
+
+    with unittest.mock.patch.dict(os.environ, {"ROCM_DEBUG_AGENT_OPTIONS":
+                                                   f"-h"}):
+        p = Popen(['./rocm-debug-agent-test', '1'], stdout=PIPE, stderr=PIPE)
+        output, err = p.communicate()
+        out_str = output.decode('utf-8')
+        err_str = err.decode('utf-8')
+
+        # check output string
+        all_output_string_found = True
+        for check_str in check_list:
+            pattern = re.compile(check_str)
+            if (not (pattern.search(err_str))):
+                all_output_string_found = False
+                print ("\"", check_str, "\" Not Found in dump.")
+
+        if (not all_output_string_found):
+            print("rocm-debug-agent test print out.")
+            print(out_str)
+            print("rocm-debug-agent test error message.")
+            print(err_str)
+
+        return all_output_string_found
+
 test_success = True
 
 for deferred_loading in (None, "1", "0"):
@@ -264,6 +294,7 @@ for deferred_loading in (None, "1", "0"):
         test_success &= check_test_3()
         test_success &= check_test_4()
         test_success &= check_test_5()
+        test_success &= check_test_6()
 
 if (test_success):
     print("rocm-debug-agent test Pass!")

--- a/test/sigquit.cpp
+++ b/test/sigquit.cpp
@@ -1,0 +1,35 @@
+#include "util.h"
+#include <hip/hip_runtime.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+__global__ void
+sigquit_kern ()
+{
+  while (true)
+    __builtin_amdgcn_s_sleep (16);
+}
+
+void
+handle_alarm (int sig)
+{
+  fprintf (stderr, "Timeout reached. Exiting.\n");
+  exit (EXIT_FAILURE);
+}
+
+void
+SigquitTest ()
+{
+  signal (SIGALRM, handle_alarm);
+  alarm (30);
+
+  hipError_t err;
+  sigquit_kern<<<1, 1>>> ();
+  err = hipDeviceSynchronize ();
+
+  alarm (0);
+
+  TEST_ASSERT (err == hipSuccess, "kernel error");
+}

--- a/test/vector_add_assert_trap_no_debug_info.cpp
+++ b/test/vector_add_assert_trap_no_debug_info.cpp
@@ -1,0 +1,128 @@
+/* The University of Illinois/NCSA
+   Open Source License (NCSA)
+
+   Copyright (c) 2020, Advanced Micro Devices, Inc. All rights reserved.
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal with the Software without restriction, including without limitation
+   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+   and/or sell copies of the Software, and to permit persons to whom the
+   Software is furnished to do so, subject to the following conditions:
+
+    - Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimers in
+      the documentation and/or other materials provided with the distribution.
+    - Neither the names of Advanced Micro Devices, Inc,
+      nor the names of its contributors may be used to endorse or promote
+      products derived from this Software without specific prior written
+      permission.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+   THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+   OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+   ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS WITH THE SOFTWARE.  */
+
+#include "util.h"
+
+#include <cstdlib>
+#include <string.h>
+#include <string>
+
+#include <hip/hip_runtime.h>
+
+#define M_ORDER 16
+#define M_GET(M, I, J) M[I * M_ORDER + J]
+#define M_SET(M, I, J, V) M[I * M_ORDER + J] = V
+
+__global__ void
+vector_add_assert_trap_no_debug (int *a, int *b, int *c)
+{
+  int gid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+
+  __shared__ long long lds_check[64];
+  lds_check[hipThreadIdx_x] = 0x1111111122222222;
+  __syncthreads ();
+
+  if (gid == 0)
+    __builtin_trap ();
+
+  c[gid] = a[gid] + b[gid] + (lds_check[0] >> 32);
+}
+
+void
+VectorAddDebugTrapTestNoDebug ()
+{
+  int *M_IN0 = nullptr;
+  int *M_IN1 = nullptr;
+  int *M_RESULT_DEVICE = nullptr;
+  int M_RESULT_HOST[M_ORDER * M_ORDER];
+  hipError_t err;
+
+  // allocate input and output kernel arguments
+  err = hipMalloc (&M_IN0, M_ORDER * M_ORDER * sizeof (int));
+  TEST_ASSERT (err == hipSuccess, "hipMalloc");
+
+  err = hipMalloc (&M_IN1, M_ORDER * M_ORDER * sizeof (int));
+  TEST_ASSERT (err == hipSuccess, "hipMalloc");
+
+  err = hipMalloc (&M_RESULT_DEVICE, M_ORDER * M_ORDER * sizeof (int));
+  TEST_ASSERT (err == hipSuccess, "hipMalloc");
+
+  memset (M_RESULT_HOST, 0, M_ORDER * M_ORDER * sizeof (int));
+  err = hipMemset (M_RESULT_DEVICE, 0, M_ORDER * M_ORDER * sizeof (int));
+  TEST_ASSERT (err == hipSuccess, "hipMemset");
+
+  int *M_IN0_HOST = (int *)malloc (M_ORDER * M_ORDER * sizeof (int));
+  int *M_IN1_HOST = (int *)malloc (M_ORDER * M_ORDER * sizeof (int));
+
+  // initialize input and run on host
+  srand (time (nullptr));
+  for (int i = 0; i < M_ORDER; ++i)
+    {
+      for (int j = 0; j < M_ORDER; ++j)
+        {
+          M_SET (M_IN0_HOST, i, j, (1 + rand () % 10));
+          M_SET (M_IN1_HOST, i, j, (1 + rand () % 10));
+        }
+    }
+
+  for (int i = 0; i < M_ORDER; ++i)
+    {
+      for (int j = 0; j < M_ORDER; ++j)
+        {
+          int s = M_GET (M_IN0_HOST, i, j) + M_GET (M_IN1_HOST, i, j);
+          M_SET (M_RESULT_HOST, i, j, s);
+        }
+    }
+
+  err = hipMemcpy (M_IN0, M_IN0_HOST, M_ORDER * M_ORDER * sizeof (int),
+                   hipMemcpyHostToDevice);
+  TEST_ASSERT (err == hipSuccess, "hipMemcpy");
+
+  err = hipMemcpy (M_IN1, M_IN1_HOST, M_ORDER * M_ORDER * sizeof (int),
+                   hipMemcpyHostToDevice);
+  TEST_ASSERT (err == hipSuccess, "hipMemcpy");
+
+  const unsigned blocks = M_ORDER * M_ORDER / 64;
+  const unsigned threadsPerBlock = 64;
+  hipLaunchKernelGGL (vector_add_assert_trap_no_debug, dim3 (blocks),
+                      dim3 (threadsPerBlock), 0, 0, M_IN0, M_IN1,
+                      M_RESULT_DEVICE);
+  err = hipDeviceSynchronize ();
+  TEST_ASSERT (err == hipSuccess, "hipDeviceSynchronize");
+
+  err = hipFree (M_IN0);
+  TEST_ASSERT (err == hipSuccess, "hipFree");
+  err = hipFree (M_IN1);
+  TEST_ASSERT (err == hipSuccess, "hipFree");
+  err = hipFree (M_RESULT_DEVICE);
+  TEST_ASSERT (err == hipSuccess, "hipFree");
+  free (M_IN0_HOST);
+  free (M_IN1_HOST);
+}


### PR DESCRIPTION
Create tests for:

  1) -o option
  2) -l option
  3) -h option
  4) -s option
  5) -a option
  6) presence of debug info in object file generated by -s option
  7) `SIGQUIT`

Basically this resolves issue: https://github.com/ROCm/rocr_debug_agent/issues/15 