### PR TITLE
refactor: Move processing of stop reason bits to separate file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,21 @@ project(rocm-debug-agent VERSION 2.1.0)
 
 include(GNUInstallDirs)
 
-file(GLOB SOURCES "src/*.cpp")
+#file(GLOB SOURCES "src/*.cpp")
+set(SOURCES
+  "src/code_object.cpp"
+  "src/debug_agent.cpp"
+  "src/logging.cpp"
+)
+
+set(UTIL_SOURCES
+  "src/stop_reason_util.cpp")
+
+add_library(stop_reason_util STATIC ${UTIL_SOURCES})
+target_include_directories(stop_reason_util PUBLIC src)
+set_target_properties(stop_reason_util PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+
 add_library(rocm-debug-agent SHARED ${SOURCES})
 
 set_target_properties(rocm-debug-agent PROPERTIES
@@ -108,8 +122,9 @@ if (HAVE_MEMFD_CREATE)
   add_definitions(-DHAVE_MEMFD_CREATE)
 endif()
 
+target_link_libraries(stop_reason_util PRIVATE amd-dbgapi)
 target_link_libraries(rocm-debug-agent
-  PRIVATE amd-dbgapi ${ROCR_LIBRARIES} ${LIBELF_LIBRARIES} ${LIBDW_LIBRARIES}
+  PRIVATE stop_reason_util amd-dbgapi ${ROCR_LIBRARIES} ${LIBELF_LIBRARIES} ${LIBDW_LIBRARIES}
   Threads::Threads ${CMAKE_DL_LIBS}
   -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/src/exportmap -Wl,--no-undefined)
 
@@ -134,6 +149,11 @@ install(TARGETS rocm-debug-agent
     NAMELINK_SKIP
     DESTINATION ${CMAKE_INSTALL_LIBDIR}
   COMPONENT asan)
+
+install(TARGETS stop_reason_util
+  ARCHIVE 
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+COMPONENT runtime)
 
 install(FILES LICENSE.txt
   DESTINATION ${CMAKE_INSTALL_DOCDIR}-asan
@@ -173,8 +193,8 @@ endif()
 set(CPACK_RPM_COMPONENT_INSTALL ON)
 set(CPACK_RPM_FILE_NAME "RPM-DEFAULT")
 set(CPACK_RPM_RUNTIME_PACKAGE_NAME "rocm-debug-agent")
-set(CPACK_RPM_RUNTIME_PACKAGE_REQUIRES "rocm-dbgapi, rocm-core")
-set(CPACK_RPM_TESTS_PACKAGE_REQUIRES "rocm-debug-agent, rocm-core")
+set(CPACK_RPM_RUNTIME_PACKAGE_REQUIRES "rocm-dbgapi, hsa-rocr, rocm-core")
+set(CPACK_RPM_TESTS_PACKAGE_REQUIRES "rocm-debug-agent, rocm-core, gtest-devel, rocm-dbgapi")
 
 # RPM package specific variable for ASAN
 set(CPACK_RPM_ASAN_PACKAGE_NAME "rocm-debug-agent-asan")
@@ -189,8 +209,8 @@ message("Using CPACK_DEBIAN_PACKAGE_RELEASE ${CPACK_DEBIAN_PACKAGE_RELEASE}")
 set(CPACK_DEB_COMPONENT_INSTALL ON)
 set(CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT")
 set(CPACK_DEBIAN_RUNTIME_PACKAGE_NAME "rocm-debug-agent")
-set(CPACK_DEBIAN_RUNTIME_PACKAGE_DEPENDS "rocm-dbgapi, rocm-core")
-set(CPACK_DEBIAN_TESTS_PACKAGE_DEPENDS "rocm-debug-agent, rocm-core")
+set(CPACK_DEBIAN_RUNTIME_PACKAGE_DEPENDS "rocm-dbgapi, hsa-rocr, rocm-core")
+set(CPACK_DEBIAN_TESTS_PACKAGE_DEPENDS "rocm-debug-agent, rocm-core, libgtest-dev, rocm-dbgapi")
 
 # Debian package specific variable for ASAN
 set(CPACK_DEBIAN_ASAN_PACKAGE_NAME "rocm-debug-agent-asan")

--- a/src/debug_agent.cpp
+++ b/src/debug_agent.cpp
@@ -31,6 +31,7 @@
 #include "code_object.h"
 #include "debug.h"
 #include "logging.h"
+#include "stop_reason_util.h"
 
 #include <amd-dbgapi/amd-dbgapi.h>
 #include <hsa/hsa.h>
@@ -666,68 +667,7 @@ print_wavefronts (amd_dbgapi_process_id_t process_id, bool all_wavefronts,
 
       agent_out << ")";
 
-      std::string stop_reason_str;
-      auto stop_reason_bits{ stop_reason };
-      do
-        {
-          /* Consume one bit from the stop reason.  */
-          auto one_bit
-              = stop_reason_bits ^ (stop_reason_bits & (stop_reason_bits - 1));
-          stop_reason_bits ^= one_bit;
-
-          if (!stop_reason_str.empty ())
-            stop_reason_str += "|";
-
-          stop_reason_str += [] (amd_dbgapi_wave_stop_reasons_t reason) {
-            switch (reason)
-              {
-              case AMD_DBGAPI_WAVE_STOP_REASON_NONE:
-                return "NONE";
-              case AMD_DBGAPI_WAVE_STOP_REASON_BREAKPOINT:
-                return "BREAKPOINT";
-              case AMD_DBGAPI_WAVE_STOP_REASON_WATCHPOINT:
-                return "WATCHPOINT";
-              case AMD_DBGAPI_WAVE_STOP_REASON_SINGLE_STEP:
-                return "SINGLE_STEP";
-              case AMD_DBGAPI_WAVE_STOP_REASON_FP_INPUT_DENORMAL:
-                return "FP_INPUT_DENORMAL";
-              case AMD_DBGAPI_WAVE_STOP_REASON_FP_DIVIDE_BY_0:
-                return "FP_DIVIDE_BY_0";
-              case AMD_DBGAPI_WAVE_STOP_REASON_FP_OVERFLOW:
-                return "FP_OVERFLOW";
-              case AMD_DBGAPI_WAVE_STOP_REASON_FP_UNDERFLOW:
-                return "FP_UNDERFLOW";
-              case AMD_DBGAPI_WAVE_STOP_REASON_FP_INEXACT:
-                return "FP_INEXACT";
-              case AMD_DBGAPI_WAVE_STOP_REASON_FP_INVALID_OPERATION:
-                return "FP_INVALID_OPERATION";
-              case AMD_DBGAPI_WAVE_STOP_REASON_INT_DIVIDE_BY_0:
-                return "INT_DIVIDE_BY_0";
-              case AMD_DBGAPI_WAVE_STOP_REASON_DEBUG_TRAP:
-                return "DEBUG_TRAP";
-              case AMD_DBGAPI_WAVE_STOP_REASON_ASSERT_TRAP:
-                return "ASSERT_TRAP";
-              case AMD_DBGAPI_WAVE_STOP_REASON_TRAP:
-                return "TRAP";
-              case AMD_DBGAPI_WAVE_STOP_REASON_MEMORY_VIOLATION:
-                return "MEMORY_VIOLATION";
-              case AMD_DBGAPI_WAVE_STOP_REASON_ADDRESS_ERROR:
-                return "ADDRESS_ERROR";
-              case AMD_DBGAPI_WAVE_STOP_REASON_ILLEGAL_INSTRUCTION:
-                return "ILLEGAL_INSTRUCTION";
-              case AMD_DBGAPI_WAVE_STOP_REASON_ECC_ERROR:
-                return "ECC_ERROR";
-              case AMD_DBGAPI_WAVE_STOP_REASON_FATAL_HALT:
-                return "FATAL_HALT";
-#if AMD_DBGAPI_VERSION_MAJOR == 0 && AMD_DBGAPI_VERSION_MINOR < 58
-              case AMD_DBGAPI_WAVE_STOP_REASON_RESERVED:
-                return "RESERVED";
-#endif
-              }
-            return "";
-          }(static_cast<amd_dbgapi_wave_stop_reasons_t> (one_bit));
-      } while (stop_reason_bits);
-
+      const std::string stop_reason_str = get_stop_reason_string (stop_reason);
       agent_out << " (";
       if (stop_reason != AMD_DBGAPI_WAVE_STOP_REASON_NONE)
         agent_out << "stopped, reason: " << stop_reason_str;
@@ -965,69 +905,9 @@ process_dbgapi_events (amd_dbgapi_process_id_t process_id, bool all_wavefronts,
       DBGAPI_CHECK (
           amd_dbgapi_wave_get_info (wave_id, AMD_DBGAPI_WAVE_INFO_STOP_REASON,
                                     sizeof (stop_reason), &stop_reason));
-      auto stop_reason_bits{ stop_reason };
 
-      std::underlying_type_t<amd_dbgapi_exceptions_t> resume_exceptions = 0;
-      do
-        {
-          auto one_bit
-              = stop_reason_bits ^ (stop_reason_bits & (stop_reason_bits - 1));
-          stop_reason_bits ^= one_bit;
-
-          switch (stop_reason)
-            {
-            case AMD_DBGAPI_WAVE_STOP_REASON_NONE:
-            case AMD_DBGAPI_WAVE_STOP_REASON_DEBUG_TRAP:
-              resume_exceptions |= AMD_DBGAPI_EXCEPTION_NONE;
-              break;
-
-            case AMD_DBGAPI_WAVE_STOP_REASON_BREAKPOINT:
-            case AMD_DBGAPI_WAVE_STOP_REASON_WATCHPOINT:
-            case AMD_DBGAPI_WAVE_STOP_REASON_ASSERT_TRAP:
-            case AMD_DBGAPI_WAVE_STOP_REASON_TRAP:
-              resume_exceptions |= AMD_DBGAPI_EXCEPTION_WAVE_TRAP;
-              break;
-
-            case AMD_DBGAPI_WAVE_STOP_REASON_SINGLE_STEP:
-              /* Is this even possible?  */
-              resume_exceptions |= AMD_DBGAPI_EXCEPTION_NONE;
-              break;
-
-            case AMD_DBGAPI_WAVE_STOP_REASON_FP_INPUT_DENORMAL:
-            case AMD_DBGAPI_WAVE_STOP_REASON_FP_DIVIDE_BY_0:
-            case AMD_DBGAPI_WAVE_STOP_REASON_FP_OVERFLOW:
-            case AMD_DBGAPI_WAVE_STOP_REASON_FP_UNDERFLOW:
-            case AMD_DBGAPI_WAVE_STOP_REASON_FP_INEXACT:
-            case AMD_DBGAPI_WAVE_STOP_REASON_FP_INVALID_OPERATION:
-            case AMD_DBGAPI_WAVE_STOP_REASON_INT_DIVIDE_BY_0:
-              resume_exceptions |= AMD_DBGAPI_EXCEPTION_WAVE_MATH_ERROR;
-              break;
-
-            case AMD_DBGAPI_WAVE_STOP_REASON_MEMORY_VIOLATION:
-              resume_exceptions |= AMD_DBGAPI_EXCEPTION_WAVE_MEMORY_VIOLATION;
-              break;
-
-            case AMD_DBGAPI_WAVE_STOP_REASON_ADDRESS_ERROR:
-              resume_exceptions
-                  |= AMD_DBGAPI_EXCEPTION_WAVE_ADDRESS_ERROR;
-              break;
-
-            case AMD_DBGAPI_WAVE_STOP_REASON_ILLEGAL_INSTRUCTION:
-              resume_exceptions
-                  |= AMD_DBGAPI_EXCEPTION_WAVE_ILLEGAL_INSTRUCTION;
-              break;
-
-            case AMD_DBGAPI_WAVE_STOP_REASON_ECC_ERROR:
-            case AMD_DBGAPI_WAVE_STOP_REASON_FATAL_HALT:
-              resume_exceptions |= AMD_DBGAPI_EXCEPTION_WAVE_ABORT;
-              break;
-
-#if AMD_DBGAPI_VERSION_MAJOR == 0 && AMD_DBGAPI_VERSION_MINOR < 58
-            case AMD_DBGAPI_WAVE_STOP_REASON_RESERVED:
-              break;
-#endif
-            }
-      } while (stop_reason_bits != 0);
+      std::underlying_type_t<amd_dbgapi_exceptions_t> resume_exceptions
+          = resume_exceptions_for_stop_reasons (stop_reason);
 
       DBGAPI_CHECK (amd_dbgapi_wave_resume (
           wave_id, AMD_DBGAPI_RESUME_MODE_NORMAL,

--- a/src/stop_reason_util.cpp
+++ b/src/stop_reason_util.cpp
@@ -1,0 +1,168 @@
+/* The University of Illinois/NCSA
+   Open Source License (NCSA)
+
+   Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal with the Software without restriction, including without limitation
+   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+   and/or sell copies of the Software, and to permit persons to whom the
+   Software is furnished to do so, subject to the following conditions:
+
+    - Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimers in
+      the documentation and/or other materials provided with the distribution.
+    - Neither the names of Advanced Micro Devices, Inc,
+      nor the names of its contributors may be used to endorse or promote
+      products derived from this Software without specific prior written
+      permission.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+   THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+   OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+   ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS WITH THE SOFTWARE.  */
+
+#include "stop_reason_util.h"
+
+std::string
+get_stop_reason_string (
+    std::underlying_type_t<amd_dbgapi_wave_stop_reasons_t> stop_reason)
+{
+  std::string stop_reason_str = "";
+  auto stop_reason_bits{ stop_reason };
+  do
+    {
+      /* Consume one bit from the stop reason.  */
+      auto one_bit
+          = stop_reason_bits ^ (stop_reason_bits & (stop_reason_bits - 1));
+      stop_reason_bits ^= one_bit;
+
+      if (!stop_reason_str.empty ())
+        stop_reason_str += "|";
+
+      stop_reason_str += [] (amd_dbgapi_wave_stop_reasons_t reason) {
+        switch (reason)
+          {
+          case AMD_DBGAPI_WAVE_STOP_REASON_NONE:
+            return "NONE";
+          case AMD_DBGAPI_WAVE_STOP_REASON_BREAKPOINT:
+            return "BREAKPOINT";
+          case AMD_DBGAPI_WAVE_STOP_REASON_WATCHPOINT:
+            return "WATCHPOINT";
+          case AMD_DBGAPI_WAVE_STOP_REASON_SINGLE_STEP:
+            return "SINGLE_STEP";
+          case AMD_DBGAPI_WAVE_STOP_REASON_FP_INPUT_DENORMAL:
+            return "FP_INPUT_DENORMAL";
+          case AMD_DBGAPI_WAVE_STOP_REASON_FP_DIVIDE_BY_0:
+            return "FP_DIVIDE_BY_0";
+          case AMD_DBGAPI_WAVE_STOP_REASON_FP_OVERFLOW:
+            return "FP_OVERFLOW";
+          case AMD_DBGAPI_WAVE_STOP_REASON_FP_UNDERFLOW:
+            return "FP_UNDERFLOW";
+          case AMD_DBGAPI_WAVE_STOP_REASON_FP_INEXACT:
+            return "FP_INEXACT";
+          case AMD_DBGAPI_WAVE_STOP_REASON_FP_INVALID_OPERATION:
+            return "FP_INVALID_OPERATION";
+          case AMD_DBGAPI_WAVE_STOP_REASON_INT_DIVIDE_BY_0:
+            return "INT_DIVIDE_BY_0";
+          case AMD_DBGAPI_WAVE_STOP_REASON_DEBUG_TRAP:
+            return "DEBUG_TRAP";
+          case AMD_DBGAPI_WAVE_STOP_REASON_ASSERT_TRAP:
+            return "ASSERT_TRAP";
+          case AMD_DBGAPI_WAVE_STOP_REASON_TRAP:
+            return "TRAP";
+          case AMD_DBGAPI_WAVE_STOP_REASON_MEMORY_VIOLATION:
+            return "MEMORY_VIOLATION";
+          case AMD_DBGAPI_WAVE_STOP_REASON_ADDRESS_ERROR:
+            return "ADDRESS_ERROR";
+          case AMD_DBGAPI_WAVE_STOP_REASON_ILLEGAL_INSTRUCTION:
+            return "ILLEGAL_INSTRUCTION";
+          case AMD_DBGAPI_WAVE_STOP_REASON_ECC_ERROR:
+            return "ECC_ERROR";
+          case AMD_DBGAPI_WAVE_STOP_REASON_FATAL_HALT:
+            return "FATAL_HALT";
+#if AMD_DBGAPI_VERSION_MAJOR == 0 && AMD_DBGAPI_VERSION_MINOR < 58
+          case AMD_DBGAPI_WAVE_STOP_REASON_RESERVED:
+            return "RESERVED";
+#endif
+          }
+        return "";
+      }(static_cast<amd_dbgapi_wave_stop_reasons_t> (one_bit));
+  } while (stop_reason_bits);
+  return stop_reason_str;
+}
+
+std::underlying_type_t<amd_dbgapi_exceptions_t>
+resume_exceptions_for_stop_reasons (
+    std::underlying_type_t<amd_dbgapi_wave_stop_reasons_t> stop_reason)
+{
+  auto stop_reason_bits{ stop_reason };
+
+  std::underlying_type_t<amd_dbgapi_exceptions_t> resume_exceptions = 0;
+  do
+    {
+      auto one_bit
+          = stop_reason_bits ^ (stop_reason_bits & (stop_reason_bits - 1));
+      stop_reason_bits ^= one_bit;
+
+      switch (stop_reason)
+        {
+        case AMD_DBGAPI_WAVE_STOP_REASON_NONE:
+        case AMD_DBGAPI_WAVE_STOP_REASON_DEBUG_TRAP:
+          resume_exceptions |= AMD_DBGAPI_EXCEPTION_NONE;
+          break;
+
+        case AMD_DBGAPI_WAVE_STOP_REASON_BREAKPOINT:
+        case AMD_DBGAPI_WAVE_STOP_REASON_WATCHPOINT:
+        case AMD_DBGAPI_WAVE_STOP_REASON_ASSERT_TRAP:
+        case AMD_DBGAPI_WAVE_STOP_REASON_TRAP:
+          resume_exceptions |= AMD_DBGAPI_EXCEPTION_WAVE_TRAP;
+          break;
+
+        case AMD_DBGAPI_WAVE_STOP_REASON_SINGLE_STEP:
+          /* Is this even possible?  */
+          resume_exceptions |= AMD_DBGAPI_EXCEPTION_NONE;
+          break;
+
+        case AMD_DBGAPI_WAVE_STOP_REASON_FP_INPUT_DENORMAL:
+        case AMD_DBGAPI_WAVE_STOP_REASON_FP_DIVIDE_BY_0:
+        case AMD_DBGAPI_WAVE_STOP_REASON_FP_OVERFLOW:
+        case AMD_DBGAPI_WAVE_STOP_REASON_FP_UNDERFLOW:
+        case AMD_DBGAPI_WAVE_STOP_REASON_FP_INEXACT:
+        case AMD_DBGAPI_WAVE_STOP_REASON_FP_INVALID_OPERATION:
+        case AMD_DBGAPI_WAVE_STOP_REASON_INT_DIVIDE_BY_0:
+          resume_exceptions |= AMD_DBGAPI_EXCEPTION_WAVE_MATH_ERROR;
+          break;
+
+        case AMD_DBGAPI_WAVE_STOP_REASON_MEMORY_VIOLATION:
+          resume_exceptions |= AMD_DBGAPI_EXCEPTION_WAVE_MEMORY_VIOLATION;
+          break;
+
+        case AMD_DBGAPI_WAVE_STOP_REASON_ADDRESS_ERROR:
+          resume_exceptions |= AMD_DBGAPI_EXCEPTION_WAVE_ADDRESS_ERROR;
+          break;
+
+        case AMD_DBGAPI_WAVE_STOP_REASON_ILLEGAL_INSTRUCTION:
+          resume_exceptions |= AMD_DBGAPI_EXCEPTION_WAVE_ILLEGAL_INSTRUCTION;
+          break;
+
+        case AMD_DBGAPI_WAVE_STOP_REASON_ECC_ERROR:
+        case AMD_DBGAPI_WAVE_STOP_REASON_FATAL_HALT:
+          resume_exceptions |= AMD_DBGAPI_EXCEPTION_WAVE_ABORT;
+          break;
+
+#if AMD_DBGAPI_VERSION_MAJOR == 0 && AMD_DBGAPI_VERSION_MINOR < 58
+        case AMD_DBGAPI_WAVE_STOP_REASON_RESERVED:
+          break;
+#endif
+        }
+  } while (stop_reason_bits != 0);
+
+  return resume_exceptions;
+}

--- a/src/stop_reason_util.h
+++ b/src/stop_reason_util.h
@@ -1,0 +1,38 @@
+/* The University of Illinois/NCSA
+   Open Source License (NCSA)
+
+   Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal with the Software without restriction, including without limitation
+   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+   and/or sell copies of the Software, and to permit persons to whom the
+   Software is furnished to do so, subject to the following conditions:
+
+    - Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimers in
+      the documentation and/or other materials provided with the distribution.
+    - Neither the names of Advanced Micro Devices, Inc,
+      nor the names of its contributors may be used to endorse or promote
+      products derived from this Software without specific prior written
+      permission.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+   THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+   OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+   ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS WITH THE SOFTWARE.  */
+
+#include <amd-dbgapi/amd-dbgapi.h>
+#include <string>
+
+std::string get_stop_reason_string (
+    std::underlying_type_t<amd_dbgapi_wave_stop_reasons_t> stop_reason);
+
+std::underlying_type_t<amd_dbgapi_exceptions_t> resume_exceptions_for_stop_reasons (
+    std::underlying_type_t<amd_dbgapi_wave_stop_reasons_t> stop_reason);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -86,3 +86,5 @@ install(FILES CMakeLists.txt run-test.py ${SOURCES} ${HEADERS}
 enable_testing()
 add_test(NAME rocm-debug-agent-test
   COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/run-test.py ${CMAKE_CURRENT_BINARY_DIR})
+
+add_subdirectory(unit)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,0 +1,76 @@
+################################################################################
+##
+## The University of Illinois/NCSA
+## Open Source License (NCSA)
+##
+## Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+##
+## Permission is hereby granted, free of charge, to any person obtaining a copy
+## of this software and associated documentation files (the "Software"), to
+## deal with the Software without restriction, including without limitation
+## the rights to use, copy, modify, merge, publish, distribute, sublicense,
+## and/or sell copies of the Software, and to permit persons to whom the
+## Software is furnished to do so, subject to the following conditions:
+##
+##  - Redistributions of source code must retain the above copyright notice,
+##    this list of conditions and the following disclaimers.
+##  - Redistributions in binary form must reproduce the above copyright
+##    notice, this list of conditions and the following disclaimers in
+##    the documentation and/or other materials provided with the distribution.
+##  - Neither the names of Advanced Micro Devices, Inc,
+##    nor the names of its contributors may be used to endorse or promote
+##    products derived from this Software without specific prior written
+##    permission.
+##
+## THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+## IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+## FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+## THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+## OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+## ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+## DEALINGS WITH THE SOFTWARE.
+##
+################################################################################
+
+cmake_minimum_required(VERSION 3.12)
+project(rocm-debug-agent-unit-tests)
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
+
+find_package(GTest REQUIRED)
+find_package(amd-dbgapi REQUIRED CONFIG
+  PATHS
+    /opt/rocm/
+  PATH_SUFFIXES
+    cmake/amd-dbgapi
+    lib/cmake/amd-dbgapi
+)
+
+set(TEST_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/get_stop_reason_string_unit_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/resume_exceptions_for_stop_reasons_unit_test.cpp
+)
+
+add_executable(stop_reason_unit_tests ${TEST_SOURCES})
+
+target_link_libraries(stop_reason_unit_tests
+    PRIVATE
+    stop_reason_util
+    amd-dbgapi
+    GTest::gtest
+    GTest::gtest_main
+    pthread
+)
+
+target_compile_options(stop_reason_unit_tests PRIVATE -ggdb)
+
+install(FILES CMakeLists.txt ${TEST_SOURCES}
+  DESTINATION src/rocm-debug-agent-test/unit
+  COMPONENT tests)
+
+install(TARGETS stop_reason_util
+LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+COMPONENT tests)
+
+enable_testing()
+add_test(NAME stop_reason_unit_tests COMMAND stop_reason_unit_tests)

--- a/test/unit/get_stop_reason_string_unit_test.cpp
+++ b/test/unit/get_stop_reason_string_unit_test.cpp
@@ -1,0 +1,102 @@
+/* The University of Illinois/NCSA
+   Open Source License (NCSA)
+
+   Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal with the Software without restriction, including without limitation
+   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+   and/or sell copies of the Software, and to permit persons to whom the
+   Software is furnished to do so, subject to the following conditions:
+
+    - Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimers in
+      the documentation and/or other materials provided with the distribution.
+    - Neither the names of Advanced Micro Devices, Inc,
+      nor the names of its contributors may be used to endorse or promote
+      products derived from this Software without specific prior written
+      permission.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+   THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+   OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+   ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS WITH THE SOFTWARE.  */
+
+#include "stop_reason_util.h"
+#include <gtest/gtest.h>
+#include <string>
+#include <type_traits>
+
+/* Unit tests. */
+TEST (GetStopReasonStringTest, SingleReason)
+{
+  EXPECT_EQ (get_stop_reason_string (AMD_DBGAPI_WAVE_STOP_REASON_NONE),
+             "NONE");
+  EXPECT_EQ (get_stop_reason_string (AMD_DBGAPI_WAVE_STOP_REASON_DEBUG_TRAP),
+             "DEBUG_TRAP");
+  EXPECT_EQ (get_stop_reason_string (AMD_DBGAPI_WAVE_STOP_REASON_BREAKPOINT),
+             "BREAKPOINT");
+  EXPECT_EQ (get_stop_reason_string (AMD_DBGAPI_WAVE_STOP_REASON_FP_OVERFLOW),
+             "FP_OVERFLOW");
+  EXPECT_EQ (get_stop_reason_string (AMD_DBGAPI_WAVE_STOP_REASON_FATAL_HALT),
+             "FATAL_HALT");
+}
+
+TEST (GetStopReasonStringTest, MultipleReasons)
+{
+  /* Order is determined by lowest bit first. */
+  auto combined = AMD_DBGAPI_WAVE_STOP_REASON_DEBUG_TRAP
+                  | AMD_DBGAPI_WAVE_STOP_REASON_BREAKPOINT;
+  EXPECT_EQ (get_stop_reason_string (combined), "BREAKPOINT|DEBUG_TRAP");
+
+  combined = AMD_DBGAPI_WAVE_STOP_REASON_FP_OVERFLOW
+             | AMD_DBGAPI_WAVE_STOP_REASON_FP_UNDERFLOW
+             | AMD_DBGAPI_WAVE_STOP_REASON_FP_INEXACT;
+  EXPECT_EQ (get_stop_reason_string (combined),
+             "FP_OVERFLOW|FP_UNDERFLOW|FP_INEXACT");
+}
+
+TEST (GetStopReasonStringTest, AllReasons)
+{
+  uint32_t all_reasons = AMD_DBGAPI_WAVE_STOP_REASON_NONE
+                         | AMD_DBGAPI_WAVE_STOP_REASON_DEBUG_TRAP
+                         | AMD_DBGAPI_WAVE_STOP_REASON_BREAKPOINT
+                         | AMD_DBGAPI_WAVE_STOP_REASON_WATCHPOINT
+                         | AMD_DBGAPI_WAVE_STOP_REASON_ASSERT_TRAP
+                         | AMD_DBGAPI_WAVE_STOP_REASON_TRAP
+                         | AMD_DBGAPI_WAVE_STOP_REASON_SINGLE_STEP
+                         | AMD_DBGAPI_WAVE_STOP_REASON_FP_INPUT_DENORMAL
+                         | AMD_DBGAPI_WAVE_STOP_REASON_FP_DIVIDE_BY_0
+                         | AMD_DBGAPI_WAVE_STOP_REASON_FP_OVERFLOW
+                         | AMD_DBGAPI_WAVE_STOP_REASON_FP_UNDERFLOW
+                         | AMD_DBGAPI_WAVE_STOP_REASON_FP_INEXACT
+                         | AMD_DBGAPI_WAVE_STOP_REASON_FP_INVALID_OPERATION
+                         | AMD_DBGAPI_WAVE_STOP_REASON_INT_DIVIDE_BY_0
+                         | AMD_DBGAPI_WAVE_STOP_REASON_MEMORY_VIOLATION
+                         | AMD_DBGAPI_WAVE_STOP_REASON_ADDRESS_ERROR
+                         | AMD_DBGAPI_WAVE_STOP_REASON_ILLEGAL_INSTRUCTION
+                         | AMD_DBGAPI_WAVE_STOP_REASON_ECC_ERROR
+                         | AMD_DBGAPI_WAVE_STOP_REASON_FATAL_HALT;
+  /* The expected string will be all names joined by '|', in order of bit
+  position. */
+  std::string expected
+      = "BREAKPOINT|WATCHPOINT|SINGLE_STEP|FP_INPUT_DENORMAL|FP_DIVIDE_BY_0|"
+        "FP_OVERFLOW|FP_UNDERFLOW|FP_INEXACT|FP_INVALID_OPERATION|INT_DIVIDE_"
+        "BY_0|DEBUG_TRAP|ASSERT_TRAP|TRAP|MEMORY_VIOLATION|ADDRESS_ERROR|"
+        "ILLEGAL_INSTRUCTION|ECC_ERROR|FATAL_HALT";
+  EXPECT_EQ (get_stop_reason_string (all_reasons), expected);
+}
+
+TEST (GetStopReasonStringTest, UnknownReason)
+{
+  /* If an unknown bit is set, it should be skipped (returns empty string for
+  that bit). */
+  uint32_t unknown = 0x40000; /* Not defined in enum. */
+  EXPECT_EQ (get_stop_reason_string (unknown), "");
+}

--- a/test/unit/resume_exceptions_for_stop_reasons_unit_test.cpp
+++ b/test/unit/resume_exceptions_for_stop_reasons_unit_test.cpp
@@ -1,0 +1,79 @@
+/* The University of Illinois/NCSA
+   Open Source License (NCSA)
+
+   Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal with the Software without restriction, including without limitation
+   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+   and/or sell copies of the Software, and to permit persons to whom the
+   Software is furnished to do so, subject to the following conditions:
+
+    - Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimers in
+      the documentation and/or other materials provided with the distribution.
+    - Neither the names of Advanced Micro Devices, Inc,
+      nor the names of its contributors may be used to endorse or promote
+      products derived from this Software without specific prior written
+      permission.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+   THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+   OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+   ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS WITH THE SOFTWARE.  */
+
+#include <gtest/gtest.h>
+#include <type_traits>
+#include "stop_reason_util.h"
+
+// Unit tests
+TEST(ProcessDbgapiStopReasonTest, NoneAndDebugTrap) {
+    EXPECT_EQ(resume_exceptions_for_stop_reasons(AMD_DBGAPI_WAVE_STOP_REASON_NONE),
+              AMD_DBGAPI_EXCEPTION_NONE);
+    EXPECT_EQ(resume_exceptions_for_stop_reasons(AMD_DBGAPI_WAVE_STOP_REASON_DEBUG_TRAP),
+              AMD_DBGAPI_EXCEPTION_NONE);
+}
+
+TEST(ProcessDbgapiStopReasonTest, WaveTrapReasons) {
+    EXPECT_EQ(resume_exceptions_for_stop_reasons(AMD_DBGAPI_WAVE_STOP_REASON_BREAKPOINT),
+              AMD_DBGAPI_EXCEPTION_WAVE_TRAP);
+    EXPECT_EQ(resume_exceptions_for_stop_reasons(AMD_DBGAPI_WAVE_STOP_REASON_WATCHPOINT),
+              AMD_DBGAPI_EXCEPTION_WAVE_TRAP);
+    EXPECT_EQ(resume_exceptions_for_stop_reasons(AMD_DBGAPI_WAVE_STOP_REASON_ASSERT_TRAP),
+              AMD_DBGAPI_EXCEPTION_WAVE_TRAP);
+    EXPECT_EQ(resume_exceptions_for_stop_reasons(AMD_DBGAPI_WAVE_STOP_REASON_TRAP),
+              AMD_DBGAPI_EXCEPTION_WAVE_TRAP);
+}
+
+TEST(ProcessDbgapiStopReasonTest, SingleStep) {
+    EXPECT_EQ(resume_exceptions_for_stop_reasons(AMD_DBGAPI_WAVE_STOP_REASON_SINGLE_STEP),
+              AMD_DBGAPI_EXCEPTION_NONE);
+}
+
+TEST(ProcessDbgapiStopReasonTest, MathErrorReasons) {
+    EXPECT_EQ(resume_exceptions_for_stop_reasons(AMD_DBGAPI_WAVE_STOP_REASON_FP_INPUT_DENORMAL),
+              AMD_DBGAPI_EXCEPTION_WAVE_MATH_ERROR);
+    EXPECT_EQ(resume_exceptions_for_stop_reasons(AMD_DBGAPI_WAVE_STOP_REASON_FP_DIVIDE_BY_0),
+              AMD_DBGAPI_EXCEPTION_WAVE_MATH_ERROR);
+    EXPECT_EQ(resume_exceptions_for_stop_reasons(AMD_DBGAPI_WAVE_STOP_REASON_FP_OVERFLOW),
+              AMD_DBGAPI_EXCEPTION_WAVE_MATH_ERROR);
+    EXPECT_EQ(resume_exceptions_for_stop_reasons(AMD_DBGAPI_WAVE_STOP_REASON_FP_UNDERFLOW),
+              AMD_DBGAPI_EXCEPTION_WAVE_MATH_ERROR);
+    EXPECT_EQ(resume_exceptions_for_stop_reasons(AMD_DBGAPI_WAVE_STOP_REASON_FP_INEXACT),
+              AMD_DBGAPI_EXCEPTION_WAVE_MATH_ERROR);
+    EXPECT_EQ(resume_exceptions_for_stop_reasons(AMD_DBGAPI_WAVE_STOP_REASON_FP_INVALID_OPERATION),
+              AMD_DBGAPI_EXCEPTION_WAVE_MATH_ERROR);
+    EXPECT_EQ(resume_exceptions_for_stop_reasons(AMD_DBGAPI_WAVE_STOP_REASON_INT_DIVIDE_BY_0),
+              AMD_DBGAPI_EXCEPTION_WAVE_MATH_ERROR);
+}
+
+TEST(ProcessDbgapiStopReasonTest, MemoryViolation) {
+    EXPECT_EQ(resume_exceptions_for_stop_reasons(AMD_DBGAPI_WAVE_STOP_REASON_MEMORY_VIOLATION),
+              AMD_DBGAPI_EXCEPTION_WAVE_MEMORY_VIOLATION);
+}


### PR DESCRIPTION
This was done to improve readability and to make writing unit tests  easier.