### PR TITLE
Add -t / --print-debugtrap to turn debugtrap into triggering events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Full documentation for the ROCR Debug Agent library is available at
 [rocm.docs.amd.com/rocr_debug_agent](https://rocm.docs.amd.com/projects/rocr_debug_agent/en/latest/).
 
+## ROCR Debug Agent 2.2.0
+
+### Added
+- Add the `-t` and `--print-debugtrap` options to print waves when they
+  execute a `__builtin_debugtrap` instruction.
+
 ## ROCR Debug Agent 2.1.0 for ROCm 7.0
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-project(rocm-debug-agent VERSION 2.1.0)
+project(rocm-debug-agent VERSION 2.2.0)
 
 include(GNUInstallDirs)
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ The supported triggering events are:
   ``__builtin_trap()`` language builtin, or ``llvm.trap`` LLVM IR instruction,
   can be used to generate this AMD GPU instruction.
 
+- __Debug trap__
+
+  This occurs when an ``s_trap 3`` instruction is executed.  The
+  ``__builtin_debugtrap()`` language builtin, or ``llvm.debugtrap`` LLVM IR
+  instruction, can be used to generate this AMD GPU instruction.  By default,
+  the debug agent ignores this trigger, unless given the ``--print-debugtrap``
+  option.
+
 - __Illegal instruction__
 
   This occurs when the hardware detects an illegal instruction.
@@ -234,6 +242,12 @@ The supported options are:
   `none`, `info`, `warning`, or `error`.
 
   The default log level is ``none``.
+
+- __``-t``, ``--print-debugtrap``__
+
+  Make the debug trap (``__builtin_debugtrap``) a trigging event which causes
+  waves to be printed by the debug agent.  Wave execution is resumed after the
+  wave state has been printed.
 
 - __``-h``, ``--help``__
 

--- a/src/debug_agent.cpp
+++ b/src/debug_agent.cpp
@@ -110,6 +110,7 @@ std::optional<std::string> g_code_objects_dir;
 bool g_all_wavefronts{ false };
 bool g_precise_emmory{ false };
 bool g_precise_alu_exceptions{ false };
+bool g_print_debugtrap{ false };
 
 /* Global state accessed by the dbgapi callbacks.  */
 std::optional<amd_dbgapi_breakpoint_id_t> g_rbrk_breakpoint_id;
@@ -819,7 +820,8 @@ print_usage ()
 
 void
 process_dbgapi_events (amd_dbgapi_process_id_t process_id, bool all_wavefronts,
-                       code_object_map_t &code_object_map)
+                       code_object_map_t &code_object_map,
+                       bool print_debugtrap)
 {
   /* Consume all events available in the queue.  */
   bool need_print_waves = false;
@@ -854,6 +856,7 @@ process_dbgapi_events (amd_dbgapi_process_id_t process_id, bool all_wavefronts,
                 /* This wave will be silently resumed at the end of this
                    procedure.  */
                 wave_need_resume = true;
+                need_print_waves |= print_debugtrap;
               }
             else
               need_print_waves = true;
@@ -1046,7 +1049,7 @@ process_dbgapi_events (amd_dbgapi_process_id_t process_id, bool all_wavefronts,
    to instruct the worker thread to stop.  */
 void
 dbgapi_worker (int listen_fd, bool all_wavefronts, bool precise_memory,
-               bool precise_alu_exceptions)
+               bool precise_alu_exceptions, bool print_debugtrap)
 {
   amd_dbgapi_process_id_t process_id;
   amd_dbgapi_event_id_t event_id;
@@ -1211,7 +1214,8 @@ dbgapi_worker (int listen_fd, bool all_wavefronts, bool precise_memory,
                            promise, which will cause the thread that modified
                            the code object list to resume.  */
                         process_dbgapi_events (process_id, all_wavefronts,
-                                               code_object_map);
+                                               code_object_map,
+                                               print_debugtrap);
                       }
 
                     g_rbrk_sync.promise->set_value ();
@@ -1229,7 +1233,7 @@ dbgapi_worker (int listen_fd, bool all_wavefronts, bool precise_memory,
                   r = read (evs[i].data.fd, &buf, 1);
               } while (r >= 0 || (r == -1 && errno == EINTR));
               process_dbgapi_events (process_id, all_wavefronts,
-                                     code_object_map);
+                                     code_object_map, print_debugtrap);
             }
           else
             agent_error ("Unknown file descriptor %d", evs[i].data.fd);
@@ -1278,7 +1282,8 @@ DebugAgentWorker::DebugAgentWorker ()
   m_write_pipe = pipefd[1];
 
   m_worker_thread = std::thread (dbgapi_worker, pipefd[0], g_all_wavefronts,
-                                 g_precise_emmory, g_precise_alu_exceptions);
+                                 g_precise_emmory, g_precise_alu_exceptions,
+                                 g_print_debugtrap);
 
   /* Wait for the worker thread to have setup dbgapi.  */
   init_future.wait ();
@@ -1485,6 +1490,7 @@ OnLoad (void *table, uint64_t runtime_version, uint64_t failed_tool_count,
           { "log-level", required_argument, nullptr, 'l' },
           { "output", required_argument, nullptr, 'o' },
           { "save-code-objects", optional_argument, nullptr, 's' },
+          { "print-debugtrap", no_argument, nullptr, 't' },
           { "precise-memory", no_argument, nullptr, 'p' },
           { "precise-alu-exceptions", no_argument, nullptr, 'e' },
           { "help", no_argument, nullptr, 'h' },
@@ -1495,7 +1501,7 @@ OnLoad (void *table, uint64_t runtime_version, uint64_t failed_tool_count,
   int saved_optind = optind;
   optind = 1;
 
-  while (int c = getopt_long (argc, argv, ":as::o:dpel:h", options, nullptr))
+  while (int c = getopt_long (argc, argv, ":as::o:dpel:ht", options, nullptr))
     {
       if (c == -1)
         break;
@@ -1563,6 +1569,10 @@ OnLoad (void *table, uint64_t runtime_version, uint64_t failed_tool_count,
             {
               g_code_objects_dir = ".";
             }
+          break;
+
+        case 't': /* -t or --print-debugtrap  */
+          g_print_debugtrap = true;
           break;
 
         case 'o': /* -o or --output  */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,7 +60,8 @@ set(MAIN_SOURCES
 	snapshot_objfile_on_load.cpp
 	vector_add_normal.cpp
 	vector_add_memory_fault.cpp
-	save_code_objects.cpp)
+	save_code_objects.cpp
+	debugtrap.cpp)
 set(NO_DEBUG_SOURCES
 	vector_add_assert_trap_no_debug_info.cpp)
 set(SOURCES ${MAIN_SOURCES} ${NO_DEBUG_SOURCES})

--- a/test/debug_agent_test.cpp
+++ b/test/debug_agent_test.cpp
@@ -40,6 +40,7 @@ extern void SaveCodeObjectTest ();
 extern void PrintAllWavesTest ();
 extern void SigquitTest ();
 extern void VectorAddDebugTrapTestNoDebug ();
+extern void DebugTrapTest ();
 
 static void PrintTestInfo (const char *header);
 static void RunVectorAddDebugTrapTest ();
@@ -50,6 +51,7 @@ static void RunSaveCodeObjectTest ();
 static void RunPrintAllWavesTest ();
 static void RunSigquitTest ();
 static void RunVectorAddDebugTrapTestNoDebug ();
+static void RunDebugTrapTest ();
 
 int
 main (int argc, char *argv[])
@@ -102,6 +104,9 @@ main (int argc, char *argv[])
           break;
         case 7:
           RunVectorAddDebugTrapTestNoDebug ();
+          break;
+        case 8:
+          RunDebugTrapTest ();
           break;
         default:
           std::cout << "  *** Invalid Test ID ***" << std::endl;
@@ -277,4 +282,25 @@ RunVectorAddDebugTrapTestNoDebug ()
       TEST_ASSERT (err == hipSuccess, "hipDeviceReset");
     }
   PrintTestInfo ("No debug info end");
+}
+
+static void
+RunDebugTrapTest ()
+{
+  PrintTestInfo ("Debug trap test start");
+  int deviceCount;
+  hipError_t err = hipGetDeviceCount (&deviceCount);
+  TEST_ASSERT (err == hipSuccess, "hipGetDeviceCount");
+
+  for (int i = 0; i < deviceCount; ++i)
+    {
+      err = hipSetDevice (i);
+      TEST_ASSERT (err == hipSuccess, "hipSetDevice");
+
+      DebugTrapTest ();
+
+      err = hipDeviceReset ();
+      TEST_ASSERT (err == hipSuccess, "hipDeviceReset");
+    }
+  PrintTestInfo ("Debug trap test end");
 }

--- a/test/debugtrap.cpp
+++ b/test/debugtrap.cpp
@@ -1,0 +1,45 @@
+/* The University of Illinois/NCSA
+   Open Source License (NCSA)
+
+   Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal with the Software without restriction, including without limitation
+   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+   and/or sell copies of the Software, and to permit persons to whom the
+   Software is furnished to do so, subject to the following conditions:
+
+    - Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimers in
+      the documentation and/or other materials provided with the distribution.
+    - Neither the names of Advanced Micro Devices, Inc,
+      nor the names of its contributors may be used to endorse or promote
+      products derived from this Software without specific prior written
+      permission.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+   THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+   OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+   ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS WITH THE SOFTWARE.  */
+
+#include "util.h"
+#include <hip/hip_runtime.h>
+
+__global__ void
+trigger_debugtrap ()
+{
+  __builtin_debugtrap ();
+}
+
+void
+DebugTrapTest ()
+{
+  trigger_debugtrap<<<1, 1>>> ();
+  TEST_ASSERT (hipDeviceSynchronize () == hipSuccess, "hipDeviceSynchronize");
+}

--- a/test/run-test.py
+++ b/test/run-test.py
@@ -601,6 +601,43 @@ def check_test_10():
     return found_in_debug and not found_in_no_debug
 
 
+# Test debug trap.
+# By default, debugtrap should not print anything.  When given the "-t" flag
+# we should see a wave dump printed.
+def test_debugtrap_test():
+    print("Start __builtin_debugtrap test")
+    out_str, err_str, success = run_and_communicate(
+        test_name="8: debugtrap, noarg", args="8"
+    )
+
+    if not success:
+        return False
+
+    if "wave_" in err_str:
+        # We expected no output.  This is an error.
+        print("Unexpected debug agent output")
+        print("rocm-debug-agent test print out.")
+        print(out_str)
+        print("rocm-debug-agent test error message.")
+        print(err_str)
+
+    # Now, test with the "-t" / "--print-debugtrap" option
+    for opt in ("-t", "--print-debugtrap"):
+        out_str, err_str, success = run_and_communicate(
+            test_name=f"8: debugtrap, {opt}", args="8", debug_agent_options=opt
+        )
+
+        if not success:
+            return False
+
+        if not check_errors(
+            [re.compile(m) for m in ("wave_", "DEBUG_TRAP")], out_str, err_str
+        ):
+            return False
+
+    return True
+
+
 test_success = True
 unsupported_tests = []
 
@@ -626,6 +663,7 @@ for deferred_loading in (None, "1", "0"):
             check_test_8,
             check_test_9,
             check_test_10,
+            test_debugtrap_test,
         ]
 
         for i, test in enumerate(test_list, start=0):


### PR DESCRIPTION
By default, debugtraps are ignored by the debug agent.  This patch makes it so the debug agent can now print wave state on debug trap.

Change-Id: I4c7a8a89b232530dd8db1493691489ba68d0b484