### PR TITLE
Improve libelf diagnostics, fix bugs and typos

### DIFF
--- a/src/code_object.cpp
+++ b/src/code_object.cpp
@@ -154,8 +154,8 @@ code_object_t::open ()
   std::string decoded_path;
   decoded_path.reserve (path.length ());
   for (size_t i = 0; i < path.length (); ++i)
-    if (path[i] == '%' && std::isxdigit (path[i + 1])
-        && std::isxdigit (path[i + 2]))
+    if (path[i] == '%' && (i + 2) < path.length ()
+        && std::isxdigit (path[i + 1]) && std::isxdigit (path[i + 2]))
       {
         decoded_path += std::stoi (path.substr (i + 1, 2), 0, 16);
         i += 2;
@@ -318,14 +318,16 @@ code_object_t::open ()
       elf_begin (fd, ELF_C_READ, nullptr), [] (Elf *elf) { elf_end (elf); });
   if (!elf)
     {
-      agent_warning ("elf_begin failed for `%s'", m_uri.c_str ());
+      agent_warning ("elf_begin failed for `%s': %s", m_uri.c_str (),
+                     elf_errmsg (0));
       return;
     }
 
   size_t phnum;
   if (elf_getphdrnum (elf.get (), &phnum) != 0)
     {
-      agent_warning ("elf_getphdrnum failed for `%s'", m_uri.c_str ());
+      agent_warning ("elf_getphdrnum failed for `%s': %s", m_uri.c_str (),
+                     elf_errmsg (0));
       return;
     }
 
@@ -335,7 +337,8 @@ code_object_t::open ()
       GElf_Phdr *phdr = gelf_getphdr (elf.get (), i, &phdr_mem);
       if (!phdr)
         {
-          agent_warning ("gelf_getphdr failed for `%s'", m_uri.c_str ());
+          agent_warning ("gelf_getphdr failed for `%s': %s", m_uri.c_str (),
+                         elf_errmsg (0));
           return;
         }
 
@@ -417,8 +420,12 @@ code_object_t::load_symbol_map ()
               || sym->st_shndx == SHN_UNDEF)
             continue;
 
-          std::string symbol_name{ elf_strptr (elf.get (), shdr->sh_link,
-                                               sym->st_name) };
+          const char *sym_name = elf_strptr (elf.get (), shdr->sh_link,
+                                            sym->st_name);
+          if (!sym_name)
+            continue;
+
+          std::string symbol_name{ sym_name };
 
           auto [it, success] = m_symbol_map->emplace (
               m_load_address + sym->st_value,
@@ -432,7 +439,7 @@ code_object_t::load_symbol_map ()
         }
     }
 
-  /* TODO: If we did not see a symbtab, check the dynamic segment.  */
+  /* TODO: If we did not see a symtab, check the dynamic segment.  */
 }
 
 void
@@ -679,7 +686,7 @@ code_object_t::disassemble (amd_dbgapi_architecture_id_t architecture_id,
           prev_file_name = file_name;
           prev_line_number = line_number;
 
-          /* If the start_pc address is not the begining of a line number
+          /* If the start_pc address is not the beginning of a line number
              block, then print ... to show that the following instruction is
              not the first in the block.  */
           if (addr == start_pc && start_pc != saved_start_pc)
@@ -746,7 +753,7 @@ code_object_t::disassemble (amd_dbgapi_architecture_id_t architecture_id,
       addr += size;
     }
 
-  /* If the end_pc address (addr) is not the begining of a new line number
+  /* If the end_pc address (addr) is not the beginning of a new line number
      block, then print ... to show that the previous instruction was
      not the last of the instructions associated with the previous source ine
      printed.  */

--- a/src/debug_agent.cpp
+++ b/src/debug_agent.cpp
@@ -108,7 +108,7 @@ using code_object_map_t
 
 std::optional<std::string> g_code_objects_dir;
 bool g_all_wavefronts{ false };
-bool g_precise_emmory{ false };
+bool g_precise_memory{ false };
 bool g_precise_alu_exceptions{ false };
 
 /* Global state accessed by the dbgapi callbacks.  */
@@ -981,7 +981,7 @@ process_dbgapi_events (amd_dbgapi_process_id_t process_id, bool all_wavefronts,
               = stop_reason_bits ^ (stop_reason_bits & (stop_reason_bits - 1));
           stop_reason_bits ^= one_bit;
 
-          switch (stop_reason)
+          switch (one_bit)
             {
             case AMD_DBGAPI_WAVE_STOP_REASON_NONE:
             case AMD_DBGAPI_WAVE_STOP_REASON_DEBUG_TRAP:
@@ -1285,7 +1285,7 @@ DebugAgentWorker::DebugAgentWorker ()
   m_write_pipe = pipefd[1];
 
   m_worker_thread = std::thread (dbgapi_worker, pipefd[0], g_all_wavefronts,
-                                 g_precise_emmory, g_precise_alu_exceptions);
+                                 g_precise_memory, g_precise_alu_exceptions);
 
   /* Wait for the worker thread to have setup dbgapi.  */
   init_future.wait ();
@@ -1333,7 +1333,7 @@ DebugAgentWorker::update_code_object_list () const
                  strerror (errno));
   agent_assert (written == 1);
 
-  /* Wait for the worker thread to acknoledge code object update has proceded
+  /* Wait for the worker thread to acknowledge code object update has proceeded
      and reset the synch structure so it can be reused in a later call.  */
   update_brk_future.wait ();
   g_rbrk_sync.promise.reset ();
@@ -1526,7 +1526,7 @@ OnLoad (void *table, uint64_t runtime_version, uint64_t failed_tool_count,
           break;
 
         case 'p': /* -p or --precise-memory  */
-          g_precise_emmory = true;
+          g_precise_memory = true;
           break;
 
         case 'e': /* -e or --precise-alu-exceptions  */

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -63,9 +63,10 @@ log (log_level_t level, const char *format, ...)
   va_end (va);
 
   va_start (va, format);
-  std::string str (size, '\0');
-  vsprintf (&str[0], format, va);
+  std::string str (size + 1, '\0');
+  vsnprintf (&str[0], size + 1, format, va);
   va_end (va);
+  str.resize (size);
 
   agent_out << str << std::endl;
 }


### PR DESCRIPTION
Add elf_errmsg () to elf_begin (), elf_getphdrnum (), gelf_getphdr () failure messages so libelf error reasons are visible.

In process_dbgapi_events (), switch on one_bit instead of stop_reason to correctly handle single bit stop-reasons.

In log (), use vsnprintf with size+1 buffer and resize to avoid buffer overrun; replace vsprintf.

In code_object_t::open (), add a bounds check when %-decoding the URI to avoid an out-of-bounds memory access.

Check elf_strptr () for null before constructing a std::string.

Fix typos.

Change-Id: I71ea1641d21190d5c2d8525e9aaf3837cc35057b